### PR TITLE
chore: allow timeout override

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ const debug = require('debug')('config-req:request');
 const formatURLPattern = require('./lib/formatURLPattern');
 
 const createInstance = (options = {}) => axios.create({
-  ...options,
   timeout: 10000,
+  ...options,
 });
 
 


### PR DESCRIPTION
This PR allows developers to set up a custom timeout for the axios instance different from the default value which is 10s right now